### PR TITLE
ci: release via GITHUB_TOKEN instead of a GitHub App token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,11 +14,6 @@ jobs:
   publish-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ secrets.RELEASEBOT_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RELEASEBOT_GITHUB_APP_KEY }}
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
@@ -56,7 +51,7 @@ jobs:
           commit-message: "[releasebot] Updates version post-release"
           branch: releasebot/version-update
           title: "[releasebot] Updates version post-release"
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: main
           body: |
             The following files have been updated as a result of releasing version: ${{ env.package_version }}.


### PR DESCRIPTION
## Problem

The `0.1.9` release failed — npm is still on `0.1.8` despite the GitHub Release existing.

The CD run ([26210504791](https://github.com/term-finance/viem-mock-contract/actions/runs/26210504791)) died at its **first step**, `actions/create-github-app-token`, with:

```
Not Found - https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app
```

The RELEASEBOT GitHub App is no longer installed on this repository (or its `RELEASEBOT_GITHUB_APP_ID` / `RELEASEBOT_GITHUB_APP_KEY` secrets are stale). Because that step ran first, the job never reached `yarn npm publish`.

## Change

- Remove the `actions/create-github-app-token` step.
- Use the workflow's built-in `GITHUB_TOKEN` for the post-release version-bump PR (`peter-evans/create-pull-request`).

This relies solely on the `permissions:` block already declared in the workflow (`contents: write`, `pull-requests: write`) — no special GitHub App required. The npm publish itself was always unaffected by the App; it uses `NPM_TOKEN`.

## Note

For the version-bump PR step to succeed with `GITHUB_TOKEN`, the repo/org setting **Settings -> Actions -> General -> "Allow GitHub Actions to create and approve pull requests"** must be enabled. If it is not, `yarn npm publish` still succeeds (it runs earlier) — only the cosmetic version-bump PR is skipped.

Verified on current `main`: `yarn install --immutable`, `yarn build:hardhat`, `yarn build:tsc`, and `yarn test` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration to streamline the continuous deployment process.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal infrastructure and automation processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/term-finance/viem-mock-contract/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->