### PR TITLE
fix: publish to npmjs.org via publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "type": "git",
     "url": "github:term-finance/viem-mock-contract"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "peerDependencies": {
     "viem": "^2.18.7"
   },


### PR DESCRIPTION
## Problem

With the app-token failure fixed (#288), the `0.1.9` CD run got all the way to `yarn npm publish` — and that step **failed**:

```
YN0000: Publishing to https://registry.yarnpkg.com with tag latest
YN0035: Response Code: 404 (Not Found)
YN0035: Request Method: PUT
YN0035: Request URL: https://registry.yarnpkg.com/@term-finance%2fviem-mock-contract
```

`registry.yarnpkg.com` is a **read-only mirror** of npm — `PUT` (publish) 404s there.

## Root cause

`yarn npm publish` resolves the publish registry in this order:

1. `package.json` `publishConfig.registry`
2. `npmScopes.<scope>.npmPublishRegistry`
3. top-level `npmPublishRegistry`
4. top-level `npmRegistryServer` (default: `https://registry.yarnpkg.com`)

The CD workflow's `.yarnrc.yml` heredoc only sets `npmScopes.term-finance.npmRegistryServer`. Yarn uses that for installs/fetches, but **never for publishing** — so publish fell through to the default `registry.yarnpkg.com`.

## Fix

Add a `publishConfig` block to `package.json` so `yarn npm publish` always targets `registry.npmjs.org` (entry 1 above — highest priority, and version-controlled rather than dependent on a CI heredoc).

Verified locally with `yarn npm publish --dry-run`:

```
➤ YN0000: Publishing to https://registry.npmjs.org with tag latest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to enable public distribution through the custom registry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/term-finance/viem-mock-contract/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->