### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ steps.nodeversion.outputs.version }}
           registry-url: "https://registry.npmjs.org"
       # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1.
-      - run: npm install --global npm@latest
+      - run: npm install --global npm@11.5.1
       - run: yarn install --immutable
       - run: yarn build:hardhat
       - run: yarn build:tsc

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ concurrency:
   group: "releasebot"
   cancel-in-progress: true
 permissions:
-  id-token: write
+  id-token: write # Required for npm trusted publishing (OIDC)
   contents: write
   pull-requests: write
 jobs:
@@ -25,26 +25,17 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.nodeversion.outputs.version }}
-          cache: yarn
           registry-url: "https://registry.npmjs.org"
-          token: ${{ secrets.NPM_TOKEN }}
-          scope: "term-finance"
-      - run: |
-          cat << EOF >> .yarnrc.yml
-
-          npmAuthToken: ${{ secrets.NPM_TOKEN }}
-          npmScopes:
-            term-finance:
-              npmRegistryServer: https://registry.npmjs.org
-              npmAuthToken: ${{ secrets.NPM_TOKEN }}
-              npmAlwaysAuth: true
-          EOF
+      # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1.
+      - run: npm install --global npm@latest
       - run: yarn install --immutable
       - run: yarn build:hardhat
       - run: yarn build:tsc
-      - run: yarn npm publish --access public
+      # Publishes via OIDC trusted publishing — no NPM_TOKEN. Authentication
+      # comes from the id-token: write permission above, and npm generates
+      # provenance attestations automatically.
+      - run: npm publish --access public
       - run: yarn version patch
-      - run: git restore .yarnrc.yml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,10 @@ node_modules
 eslint.config.mjs
 hardhat.config.ts
 
+# Yarn files (publishing uses the npm CLI, which would otherwise bundle these)
+.yarn
+.yarnrc.yml
+
 # Hardhat files
 /cache
 /test


### PR DESCRIPTION
Updates `cd.yml` to publish through the **npm trusted publisher (OIDC)** that is now configured on npmjs.com for this repo's `cd.yml` workflow — no more long-lived `NPM_TOKEN`.

Follows https://docs.npmjs.com/trusted-publishers.

## Changes

**`.github/workflows/cd.yml`**
- Remove `NPM_TOKEN` entirely — dropped from `setup-node`, and the `.yarnrc.yml` auth heredoc (plus the `git restore .yarnrc.yml` that undid it) is deleted.
- Switch the publish step from `yarn npm publish` to **`npm publish`**. Yarn's publisher does not perform npm's OIDC token exchange (it returns `404 Not Found`); the documented pattern is to **build with Yarn, publish with the npm CLI**.
- Add `npm install --global npm@latest` — OIDC trusted publishing requires **npm CLI ≥ 11.5.1**. Node `22.22.3` (from `.tool-versions`) already satisfies the **≥ 22.14.0** requirement.
- Drop `cache: yarn` (docs advise against caching in release builds).
- `permissions.id-token: write` is retained — this is what authenticates the publish.

**`.npmignore`**
- Exclude `.yarn` and `.yarnrc.yml`. `yarn npm publish` skipped these automatically; `npm publish` would otherwise bundle them — including the 3 MB `.yarn/releases/yarn-*.cjs`.

## Verification

`npm publish --dry-run` packs exactly the same **18 files** as the previous `yarn npm publish` (no `.yarn/` bloat):

```
total files: 18
Publishing to https://registry.npmjs.org with tag latest and public access (dry-run)
```

OIDC authentication and provenance can only be exercised in the real GitHub Actions run.

## Note

If the npm trusted-publisher config specifies a deployment **Environment**, the `publish-package` job must also set `environment: <name>`. It currently sets none — fine as long as the npm config left Environment blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched package publishing to a more secure, token-less trusted workflow.
  * Updated the publish flow to use current tooling and automatic version bumping.
  * Excluded Yarn-related files from published packages to reduce package size and surface extraneous config, improving distribution cleanliness and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/term-finance/viem-mock-contract/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->