### PR TITLE
feat: ship .d.ts declarations; robust contractAddress cast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ node_modules
 
 # Typescript files
 **/*.js
+**/*.d.ts
 *.tgz

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default tseslint.config(
   {
     ignores: [
       "**/*.js",
+      "**/*.d.ts",
       "node_modules/",
       "artifacts/",
       "cache/",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "version": "0.1.10",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "license": "MIT",
   "homepage": "https://github.com/term-finance/viem-mock-contract",
   "bugs": {

--- a/src/mock-contract.ts
+++ b/src/mock-contract.ts
@@ -74,8 +74,12 @@ export const deployMock = async (
   const deployTxReceipt = await reader.waitForTransactionReceipt({
     hash: deployTxHash,
   });
-  const address: `0x${string}` | null | undefined =
-    deployTxReceipt.contractAddress;
+  // `contractAddress` widens to `string` under the formatted-receipt types of
+  // some viem versions; cast so MockContractController.address stays well-typed.
+  const address = deployTxReceipt.contractAddress as
+    | `0x${string}`
+    | null
+    | undefined;
   if (!address) {
     throw new Error("Contract did not deploy correctly");
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "declaration": true
   },
   "exclude": ["hardhat.config.ts", "test/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

`@term-finance/viem-mock-contract` ships `src/*.js` + `src/*.ts` but **no declaration files and no `types` field**. So when a consumer imports it, TypeScript resolves to and type-checks the raw `src/*.ts` source — against the **consumer's** `viem` version, not the one this package was built with.

viem's formatted transaction-receipt types widen `contractAddress` to `string` in some versions. `mock-contract.ts` annotated the deployed address as `` `0x${string}` | null | undefined ``, which only holds when the right-hand side is already `Address`. Result: this package builds cleanly against its own `viem` (`^2.50.4`), but a consumer on an older `viem` (e.g. term-finance-ui on `2.48.11`) gets:

```
mock-contract.ts(77,9): error TS2322: Type 'string | null | undefined' is not assignable to type '`0x${string}` | null | undefined'.
```

## Changes

- **Ship declaration files.** `declaration: true` in `tsconfig.json`, and a `types` entry in `package.json`. `build:tsc` now emits `src/*.d.ts` alongside `src/*.js`, and they're included in the published tarball. Consumers resolve to the shipped `.d.ts` (skipped under `skipLibCheck`) and **never re-type-check the source** — permanently removing this whole class of version-skew breakage.
- **Robust cast.** `mock-contract.ts` now casts `contractAddress` instead of annotating the variable, so the package's own build is also robust to that widening.
- **Ignore generated `.d.ts`** in `.gitignore` and `eslint.config.mjs`, matching the existing treatment of generated `**/*.js`.

## Verification

- `yarn build:hardhat`, `yarn build:tsc` — pass; emits `src/index.d.ts`, `src/mock-contract.d.ts`, `src/compat/waffle.d.ts`.
- `yarn test` — 10 passing, 1 pending.
- `yarn check:eslint`, `yarn check:prettier` — clean.
- `npm publish --dry-run` — 21 files, now including the three `src/*.d.ts`.

Releasing this as `0.1.10` lets term-finance-ui consume it with zero residual type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript support by enabling declaration file generation and configuring the package's type entry point, improving type availability for TypeScript consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/term-finance/viem-mock-contract/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->