### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for stylebot instead of suspended GitHub App

### DIFF
--- a/.github/workflows/stylebot.yml
+++ b/.github/workflows/stylebot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: nodeversion
-        run: echo "::set-output name=version::$(grep nodejs .tool-versions | sed -e 's/[^[:space:]]*[[:space:]]*//')"
+        run: echo "version=$(grep nodejs .tool-versions | sed -e 's/[^[:space:]]*[[:space:]]*//')" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.nodeversion.outputs.version }}

--- a/.github/workflows/stylebot.yml
+++ b/.github/workflows/stylebot.yml
@@ -7,14 +7,13 @@ concurrency:
   group: "stylebot"
   cancel-in-progress: true
 permissions:
-  id-token: write
   contents: write
   pull-requests: write
 jobs:
   fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - id: nodeversion
         run: echo "::set-output name=version::$(grep nodejs .tool-versions | sed -e 's/[^[:space:]]*[[:space:]]*//')"
       - uses: actions/setup-node@v6
@@ -35,7 +34,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           commit-message: "[stylebot] Fixes for code style"
           branch: stylebot/patch
           title: "[stylebot] Fixes for code style"

--- a/.github/workflows/stylebot.yml
+++ b/.github/workflows/stylebot.yml
@@ -14,11 +14,6 @@ jobs:
   fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ secrets.STYLEBOT_GITHUB_APP_ID }}
-          private-key: ${{ secrets.STYLEBOT_GITHUB_APP_KEY }}
       - uses: actions/checkout@master
       - id: nodeversion
         run: echo "::set-output name=version::$(grep nodejs .tool-versions | sed -e 's/[^[:space:]]*[[:space:]]*//')"
@@ -40,7 +35,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "[stylebot] Fixes for code style"
           branch: stylebot/patch
           title: "[stylebot] Fixes for code style"


### PR DESCRIPTION
## Problem
The stylebot `fix` job fails on every push to `main` at the `actions/create-github-app-token` step with `403 "This installation has been suspended"`. The STYLEBOT GitHub App installation is suspended org-wide.

## Fix
Drop the GitHub App token and use the built-in `GITHUB_TOKEN`. The `permissions` block grants the `contents: write` + `pull-requests: write` that `create-pull-request` needs.

## Caveats (inherent to `GITHUB_TOKEN`)
1. PRs opened by `GITHUB_TOKEN` do not trigger downstream workflow runs. Fine for style-only PRs.
2. Requires Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests" to be enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation used for pull request creation to authenticate with the built-in repository token.
  * Simplified the workflow by removing an extra token-generation step.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->