### PR TITLE
chore: group related dependency updates in renovate/dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,6 @@ updates:
           - "@eslint/*"
           - "typescript-eslint"
           - "@types/eslint__js"
-      typescript:
-        patterns:
-          - "typescript"
-          - "ts-node"
-          - "@types/*"
-        exclude-patterns:
-          - "@types/eslint__js"
       viem:
         patterns:
           - "viem"
@@ -39,3 +32,10 @@ updates:
           - "chai"
           - "@types/chai"
           - "@types/chai-as-promised"
+      typescript:
+        patterns:
+          - "typescript"
+          - "ts-node"
+          - "@types/*"
+        exclude-patterns:
+          - "@types/eslint__js"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,35 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "autoApprove": true
+    },
+    {
+      "groupName": "typescript",
+      "matchPackageNames": ["typescript", "ts-node", "@types/**"]
+    },
+    {
+      "groupName": "hardhat",
+      "matchPackageNames": ["hardhat", "hardhat-**", "@nomicfoundation/**"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/**",
+        "typescript-eslint",
+        "@types/eslint__js"
+      ]
+    },
+    {
+      "groupName": "viem",
+      "matchPackageNames": ["viem", "abitype"]
+    },
+    {
+      "groupName": "prettier",
+      "matchPackageNames": ["prettier"]
+    },
+    {
+      "groupName": "chai",
+      "matchPackageNames": ["chai", "@types/chai", "@types/chai-as-promised"]
     }
   ]
 }


### PR DESCRIPTION
Groups semantically related packages so they are upgraded together in a single update PR, e.g. all hardhat packages. Changes `.github/renovate.json` and `.github/dependabot.yml`.

| Group | Packages covered |
| --- | --- |
| hardhat | `hardhat`, `@nomicfoundation/hardhat-ignition`, `@nomicfoundation/hardhat-ignition-viem`, `@nomicfoundation/hardhat-keystore`, `@nomicfoundation/hardhat-network-helpers`, `@nomicfoundation/hardhat-node-test-runner`, `@nomicfoundation/hardhat-toolbox-viem`, `@nomicfoundation/hardhat-verify`, `@nomicfoundation/hardhat-viem`, `@nomicfoundation/hardhat-viem-assertions`, `@nomicfoundation/ignition-core` |
| eslint | `eslint`, `@eslint/js`, `typescript-eslint`, `@types/eslint__js` |
| typescript | `typescript`, `ts-node`, `@types/mocha`, `@types/node` |
| viem | `viem`, `abitype` |
| prettier | `prettier` |
| chai | `chai`, `@types/chai`, `@types/chai-as-promised` |

The hardhat, eslint, typescript, viem, and prettier groups apply to renovate; the chai group applies to both renovate and dependabot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update organization.
  * Grouped related TypeScript, Hardhat, ESLint, Viem, Prettier, and Chai updates for clearer maintenance and review.
  * Preserved existing automated approval and merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->